### PR TITLE
Lab new unit test and controller

### DIFF
--- a/flask_backend/api/__init__.py
+++ b/flask_backend/api/__init__.py
@@ -13,6 +13,7 @@ from .controllers import (
     fake_api_controller,
     user_controller,
     assignment_controller,
+    practice_controller,
 )
 from .models.db import db, ma
 
@@ -107,6 +108,7 @@ def create_app(test_config=None):
     app.register_blueprint(admin_controller.bp)
     app.register_blueprint(class_controller.bp)
     app.register_blueprint(assignment_controller.bp)
+    app.register_blueprint(practice_controller.bp)
     app.register_blueprint(fake_api_controller.fake)
 
     return app

--- a/flask_backend/api/controllers/practice_controller.py
+++ b/flask_backend/api/controllers/practice_controller.py
@@ -1,0 +1,11 @@
+from flask import Blueprint, jsonify
+
+bp = Blueprint("practice", __name__, url_prefix="/practice")
+
+
+@bp.route("/test", methods=["GET"])
+def test():
+    """
+    Test endpoint that returns a JSON object with course as the key and cosc 224 as the value.
+    """
+    return jsonify({"course": "cosc 224"}), 200

--- a/flask_backend/tests/test_ryan.py
+++ b/flask_backend/tests/test_ryan.py
@@ -1,0 +1,17 @@
+"""
+Tests for practice endpoints
+"""
+
+
+def test_practice_endpoint(test_client):
+    """
+    GIVEN a test client
+    WHEN GET /practice/test is called
+    THEN the response should have status 200, contain course key, and value should be cosc 224
+    """
+    response = test_client.get("/practice/test")
+
+    assert response.status_code == 200
+    assert response.json is not None
+    assert "course" in response.json
+    assert response.json["course"] == "cosc 224"


### PR DESCRIPTION
Add a new practice blueprint with a /practice/test GET endpoint that returns {"course": "cosc 224"}. Register the blueprint in flask_backend/api/__init__.py and add flask_backend/tests/test_ryan.py to validate the endpoint returns status 200 and the expected payload.