### PR TITLE
Add admin dashboard UI and navigation

### DIFF
--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -21,6 +21,17 @@
   padding: var(--spacing-md) 0;
 }
 
+.ClassesSection {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.ClassesTitle {
+  margin: 0;
+  color: var(--text-primary);
+}
+
 .ClassCreateButton {
   display: flex;
   flex-direction: column;
@@ -60,6 +71,79 @@
     display: flex;
     flex-direction: column;
     gap: var(--spacing-md);
+}
+
+.AdminIntro {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-md);
+  padding: var(--spacing-md);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius-lg);
+  background: var(--background-secondary);
+}
+
+.AdminIntroText {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.AdminStats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-md);
+}
+
+.AdminStatCard {
+  min-width: 180px;
+  padding: var(--spacing-md);
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--border-color);
+  background: var(--background-primary);
+}
+
+.AdminStatValue {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.AdminStatLabel {
+  margin-top: var(--spacing-xs);
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.AdminActions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--spacing-md);
+}
+
+.AdminActionCard {
+  text-align: left;
+  padding: var(--spacing-md);
+  border: 1px solid var(--border-color);
+  border-radius: var(--border-radius-md);
+  background: var(--background-primary);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
+}
+
+.AdminActionCard:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-sm);
+  border-color: var(--button-primary);
+}
+
+.AdminActionCard h3 {
+  margin: 0 0 var(--spacing-xs) 0;
+}
+
+.AdminActionCard p {
+  margin: 0;
+  color: var(--text-secondary);
 }
 
 .SearchInput {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import ClassCard from "../components/ClassCard";
 import StatusMessage from "../components/StatusMessage";
 
@@ -7,11 +8,27 @@ import { listClasses, listAssignments, searchClasses } from "../util/api";
 import { isTeacher, isAdmin } from "../util/login";
 
 export default function Home() {
+  const navigate = useNavigate();
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const classesSectionRef = useRef<HTMLDivElement | null>(null);
   const [courses, setCourses] = useState<CourseWithAssignments[]>([]);
   const [allCourses, setAllCourses] = useState<CourseWithAssignments[] | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState<string>("");
+
+  const adminMode = isAdmin();
+  const totalAssignments = courses.reduce((sum, course) => sum + Number(course.assignmentCount || 0), 0);
+
+  const handleBrowseClasses = () => {
+    if (allCourses) {
+      setCourses(allCourses);
+    }
+    setSearchQuery("");
+    setErrorMessage("");
+    classesSectionRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    searchInputRef.current?.focus();
+  };
 
   useEffect(() => {
     ;(async () => {
@@ -148,7 +165,7 @@ export default function Home() {
   if (loading) {
     return (
       <div className="Home Page">
-        <h1>Peer Review Dashboard</h1>
+        <h1>{adminMode ? "Admin Dashboard" : "Peer Review Dashboard"}</h1>
         <p className="PageStatusText">Loading…</p>
       </div>
     );
@@ -156,19 +173,52 @@ export default function Home() {
 
   return (
     <div className="Home Page">
-      <h1>Peer Review Dashboard</h1>
+      <h1>{adminMode ? "Admin Dashboard" : "Peer Review Dashboard"}</h1>
 
       <StatusMessage message={errorMessage} type="error" />
 
+      {adminMode ? (
+        <div className="AdminIntro">
+          <p className="AdminIntroText">
+            Manage users, monitor classes, and quickly jump into course spaces.
+          </p>
+          <div className="AdminStats">
+            <div className="AdminStatCard">
+              <div className="AdminStatValue">{courses.length}</div>
+              <div className="AdminStatLabel">Visible classes</div>
+            </div>
+            <div className="AdminStatCard">
+              <div className="AdminStatValue">{totalAssignments}</div>
+              <div className="AdminStatLabel">Assignments across classes</div>
+            </div>
+          </div>
+
+          <div className="AdminActions">
+            <button className="AdminActionCard" onClick={() => navigate('/admin/users')}>
+              <h3>Manage Users</h3>
+              <p>Create users, update roles, and manage account access.</p>
+            </button>
+            <button className="AdminActionCard" onClick={handleBrowseClasses}>
+              <h3>Browse Classes</h3>
+              <p>Jump to class directory and search classes you can inspect.</p>
+            </button>
+          </div>
+        </div>
+      ) : null}
+
       <div className="Search">
         <input
+          ref={searchInputRef}
           type="text"
           className="SearchInput"
-          placeholder="Search for Courses"
+          placeholder={adminMode ? "Search classes to inspect" : "Search for Courses"}
           value={searchQuery}
           onChange={(e) => handleSearch(e.target.value)}
         />
       </div>
+
+      <div className="ClassesSection" ref={classesSectionRef}>
+        {adminMode ? <h2 className="ClassesTitle">Class Directory</h2> : null}
 
       <div className="Classes">
         {
@@ -188,7 +238,7 @@ export default function Home() {
                   name={course.name}
                   subtitle={assignmentText}
                   onclick={() => {
-                    window.location.href = `/classes/${course.id}/home`;
+                    navigate(`/classes/${course.id}/home`);
                   }}
                 />
               );
@@ -196,13 +246,10 @@ export default function Home() {
           )
         }
 
-        {isTeacher() && <div className="ClassCreateButton" onClick={() => window.location.href = '/classes/create'}>
+        {isTeacher() && !adminMode && <div className="ClassCreateButton" onClick={() => navigate('/classes/create')}>
           <h2>Create Class</h2>
         </div>}
-        
-        {isAdmin() && <div className="ClassCreateButton" onClick={() => window.location.href = '/admin/users'}>
-          <h2>Manage Users</h2>
-        </div>}
+      </div>
       </div>
     </div>
   )


### PR DESCRIPTION
Introduce admin-oriented UI and layout to the Home page and related styles. Home.tsx: add useNavigate, refs (search input and classes section), adminMode flag, total assignment count, and handleBrowseClasses to scroll and focus; conditionally render an AdminIntro with stats and action cards (Manage Users, Browse Classes); switch direct window.location.href uses to navigate(); update headings and search placeholder for admin mode; restrict class creation button for admin users. Home.css: add styles for .ClassesSection, .ClassesTitle and a set of admin-specific styles (.AdminIntro, .AdminStats, .AdminStatCard, .AdminActionCard, etc.) to support layout, cards, and hover effects.